### PR TITLE
[Feat] 사용자 정보 반환 api 구현

### DIFF
--- a/src/main/java/com/example/eatmate/global/auth/jwt/JwtService.java
+++ b/src/main/java/com/example/eatmate/global/auth/jwt/JwtService.java
@@ -152,7 +152,7 @@ public class JwtService {
         memberRepository.findByEmail(email).ifPresentOrElse(
                 member -> {
                     member.updateRefreshToken(refreshToken);
-                    memberRepository.save(member);
+                    memberRepository.saveAndFlush(member);
                 },
                 () -> {
                     throw new UserNotFoundException();

--- a/src/main/java/com/example/eatmate/global/auth/login/controller/AuthController.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/controller/AuthController.java
@@ -1,13 +1,15 @@
 package com.example.eatmate.global.auth.login.controller;
 
+import com.example.eatmate.global.auth.jwt.JwtService;
+import com.example.eatmate.global.auth.login.dto.UserLoginResponseDto;
+import com.example.eatmate.global.auth.login.service.LoginService;
+import com.example.eatmate.global.config.error.exception.CommonException;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.example.eatmate.app.domain.member.dto.MemberSignUpRequestDto;
 import com.example.eatmate.app.domain.member.service.MemberService;
@@ -23,6 +25,8 @@ import lombok.RequiredArgsConstructor;
 public class AuthController {
 
 	private final MemberService memberService;
+	private final JwtService jwtService;
+	private final LoginService loginService;
 
 	//회원가입
 	@PostMapping("/signup") //매핑 경로 수정
@@ -36,5 +40,16 @@ public class AuthController {
 				HttpStatus.CREATED.value()));
 	}
 
-	//로그아웃
+	//로그인 시, 사용자 정보 조회
+	@GetMapping("/info")
+	@Operation(summary = "사용자 정보 조회", description = "로그인 기반으로 사용자 정보를 조회합니다.")
+	public ResponseEntity<GlobalResponseDto<UserLoginResponseDto>> getUserInfo(HttpServletRequest request) {
+
+		UserLoginResponseDto userInfo = loginService.getUserInfoFromRequest(request);
+
+		return ResponseEntity.ok(GlobalResponseDto.success(userInfo, HttpStatus.OK.value()));
+	}
+
+
+
 }

--- a/src/main/java/com/example/eatmate/global/auth/login/dto/UserLoginResponseDto.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/dto/UserLoginResponseDto.java
@@ -1,0 +1,15 @@
+package com.example.eatmate.global.auth.login.dto;
+
+import com.example.eatmate.app.domain.member.domain.Role;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserLoginResponseDto {
+
+    private String email;
+    private Role role;
+}

--- a/src/main/java/com/example/eatmate/global/auth/login/oauth/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/oauth/OAuthLoginSuccessHandler.java
@@ -22,7 +22,7 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
     private final JwtService jwtService;
 
     private static final boolean COOKIE_HTTP_ONLY = true;
-    private static final boolean COOKIE_SECURE = false;
+    private static final boolean COOKIE_SECURE = true; //https 환경에서는 true
     private static final String COOKIE_PATH = "/";
     private static final int ACCESS_TOKEN_MAX_AGE = 60 * 60; // 1시간
     private static final int REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 7; // 7일

--- a/src/main/java/com/example/eatmate/global/auth/login/oauth/OAuthLoginSuccessHandler.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/oauth/OAuthLoginSuccessHandler.java
@@ -30,26 +30,20 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         log.info("OAuth2 Login 성공");
-
         try {
             CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
-
             // 사용자 Role 확인
             Role userRole = oAuth2User.getRole();
-
             //토큰 생성
             String accessToken = jwtService.createAccessToken(oAuth2User.getEmail(), oAuth2User.getRole().name() );
             String refreshToken = null;
-
             if (userRole == Role.USER) {
                 refreshToken = jwtService.createRefreshToken();
                 jwtService.updateRefreshToken(oAuth2User.getEmail(), refreshToken);
             }
             logTokens(accessToken, refreshToken);
-
             setTokensInCookie(response,accessToken, refreshToken);
-
-			response.sendRedirect("http://localhost:3000/oauth2/callback");
+            response.sendRedirect("http://localhost:3000/oauth2/callback");
         } catch (Exception e) {
             log.error("OAuth2 로그인 처리 중 오류 발생: {} " , e.getMessage());
             throw e;
@@ -58,6 +52,9 @@ public class OAuthLoginSuccessHandler implements AuthenticationSuccessHandler {
 
 // 쿠키 설정 메소드 생성
     private void setTokensInCookie(HttpServletResponse response, String accessToken, String refreshToken) {
+
+
+
         // Access Token 쿠키 설정
         Cookie accessTokenCookie = new Cookie("AccessToken", accessToken);
         accessTokenCookie.setHttpOnly(COOKIE_HTTP_ONLY);

--- a/src/main/java/com/example/eatmate/global/auth/login/service/LoginService.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/service/LoginService.java
@@ -3,8 +3,15 @@ package com.example.eatmate.global.auth.login.service;
 import static org.springframework.security.core.userdetails.User.*;
 
 import com.example.eatmate.app.domain.member.domain.Member;
+import com.example.eatmate.app.domain.member.domain.Role;
 import com.example.eatmate.app.domain.member.domain.repository.MemberRepository;
+import com.example.eatmate.global.auth.jwt.JwtService;
+import com.example.eatmate.global.auth.login.dto.UserLoginResponseDto;
+import com.example.eatmate.global.config.error.ErrorCode;
+import com.example.eatmate.global.config.error.exception.CommonException;
+import com.example.eatmate.global.config.error.exception.custom.InvalidTokenException;
 import com.example.eatmate.global.config.error.exception.custom.UserNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -17,6 +24,7 @@ import org.springframework.stereotype.Service;
 public class LoginService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
+    private final JwtService jwtService;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UserNotFoundException {
@@ -28,4 +36,31 @@ public class LoginService implements UserDetailsService {
                 .username(member.getEmail())
                 .build();
     }
+
+    public UserLoginResponseDto getUserInfoFromRequest(HttpServletRequest request) {
+        // 쿠키에서 AccessToken 추출
+        String accessToken = jwtService.extractAccessTokenFromCookie(request)
+                .orElseThrow(() -> new CommonException(ErrorCode.TOKEN_NOT_FOUND));
+
+        // AccessToken 유효성 검증 및 사용자 정보 조회
+        return getUserInfo(accessToken);
+    }
+
+    public UserLoginResponseDto getUserInfo(String accessToken) {
+        // AccessToken 유효성 검증
+        if (!jwtService.isTokenValid(accessToken)) {
+            throw new CommonException(ErrorCode.INVALID_TOKEN);
+        }
+        // AccessToken에서 이메일과 역할(Role) 추출
+        String email = jwtService.extractEmail(accessToken)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
+        String role = jwtService.extractRole(accessToken)
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALID_TOKEN));
+
+        // 사용자 정보 반환
+        return new UserLoginResponseDto(email, Role.valueOf(role));
+    }
+
+
+
 }

--- a/src/main/java/com/example/eatmate/global/config/error/ErrorCode.java
+++ b/src/main/java/com/example/eatmate/global/config/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
 
 	//회원
 	USER_NOT_FOUND(404, "USER_NOT_FOUND", "유저를 찾을 수 없습니다."),
+	TOKEN_NOT_FOUND(404, "TOKEN_NOT_FOUND", "토큰를 찾을 수 없습니다."),
 	MEMBER_ALREADY_EXISTS(409, "MEMBER_ALREADY_EXISTS", "이미 가입된 이메일입니다."),
 	DUPLICATE_PHONE_NUMBER(409, "DUPLICATE_PHONE_NUMBER", "이미 사용 중인 전화번호입니다."),
 	DUPLICATE_STUDENT_NUMBER(409, "DUPLICATE_STUDENT_NUMBER", "이미 사용 중인 학번입니다."),


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #이슈
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
HTTPS 환경에서의 요청에 쿠키를 포함할 수 있게끔 Cookle SECURE를 true로 변경하였습니다. (개발환경에서는 false) 
로그인 후, 프론트 콜백 페이지로 리다이렉트 되면 거기서 api 요청을 통해 사용자 정보(ROLE, 이메일 )등을 응답 받을 수 있습니다.

토큰 재발급 api 도 처음엔 구현하였으나, jwt필터에서 이미 해주는 작업이라 제거하였습니다.
최초 로그인일때  get요청 시 , 요청 결과
<img width="702" alt="스크린샷 2025-01-09 오전 2 37 05" src="https://github.com/user-attachments/assets/5cabccf1-592d-417b-b211-e63a50be0b4e" />

회원가입 후 , 로그인하고 get 요청 시,
<img width="735" alt="스크린샷 2025-01-09 오전 2 39 12" src="https://github.com/user-attachments/assets/a2692012-dcb4-4d46-ac9d-ec3143697032" />

최초 로그인일때  get요청 시 , 요청 결과

하나 의문인 점이 있다면 개발자 도구에서 쿠키 목록을 보면,
<img width="1431" alt="스크린샷 2025-01-09 오전 2 59 28" src="https://github.com/user-attachments/assets/8deeded8-74fb-4a73-84d6-5cf210d1808e" />
AccessToken, RefreshToken 이외에도  Authorization, Authorization-refresh가 존재하는데 이 둘의 값은 같으며, 
postman 요청 시 ,
AccessToken=어세스토큰 값; RefreshToken= (리프레시토큰값이 아닌)Authorization, Authorization-refresh의 값을 넣어야 요청이 성공하였습니다. 

추후에 회원가입을 한 후에도 바뀌는 어세스토큰 값만 바꿔주고 Authorization, Authorization-refresh 값은 고정된채로 요청을 넣으니 조회에 성공하였습니다.

리프레시 토큰 값을 넣으면 Invalid Refresh 토큰이라고 나오는데 
다같이 코드 리뷰하면서 원인을 찾을 수 있으면 좋겠습니다.. 
우선 로직은 돌아갑니다..
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
잦은 PR 죄송합니다. 프론트 분과 연결단계여서 시행착오가 잦습니다.. ^^ 
