### PR TITLE
[Add] 프로필 사진 필드 추가

### DIFF
--- a/src/main/java/com/example/eatmate/app/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/controller/MemberController.java
@@ -53,7 +53,7 @@ public class MemberController {
 	@Operation(summary = "프로필 수정", description = "사용자의 닉네임, 전화번호, MBTI, 생년월일을 일부 수정합니다.")
 	public ResponseEntity<GlobalResponseDto<MyInfoResponseDto>> updateMyProfile(
 		@RequestPart(value = "data") @Valid MyInfoUpdateRequestDto updateRequestDto,
-		@RequestPart(value = "profileImage") MultipartFile profileImage,
+		@RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
 		@AuthenticationPrincipal UserDetails userDetails
 	) {
 		return ResponseEntity.ok(

--- a/src/main/java/com/example/eatmate/app/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/controller/MemberController.java
@@ -8,7 +8,9 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.eatmate.app.domain.member.dto.MemberLoginRequestDto;
 import com.example.eatmate.app.domain.member.dto.MemberLoginResponseDto;
@@ -50,11 +52,12 @@ public class MemberController {
 	@PatchMapping("/myinfo")
 	@Operation(summary = "프로필 수정", description = "사용자의 닉네임, 전화번호, MBTI, 생년월일을 일부 수정합니다.")
 	public ResponseEntity<GlobalResponseDto<MyInfoResponseDto>> updateMyProfile(
-		@RequestBody @Valid MyInfoUpdateRequestDto updateRequestDto,
+		@RequestPart(value = "data") @Valid MyInfoUpdateRequestDto updateRequestDto,
+		@RequestPart(value = "profileImage") MultipartFile profileImage,
 		@AuthenticationPrincipal UserDetails userDetails
 	) {
 		return ResponseEntity.ok(
-			GlobalResponseDto.success(memberService.updateMyInfo(userDetails, updateRequestDto))
+			GlobalResponseDto.success(memberService.updateMyInfo(userDetails, updateRequestDto, profileImage))
 		);
 	}
 }

--- a/src/main/java/com/example/eatmate/app/domain/member/domain/Member.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.example.eatmate.app.domain.member.domain;
 
 import static com.example.eatmate.app.domain.member.domain.Role.*;
 
+import com.example.eatmate.app.domain.image.domain.Image;
 import com.example.eatmate.global.common.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -9,9 +10,12 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -62,9 +66,14 @@ public class Member extends BaseTimeEntity {
 	@Embedded
 	private BirthDate birthDate;   // yyyy-mm-dd 형식으로 받아야함
 
+	@OneToOne(fetch = FetchType.LAZY, orphanRemoval = true)
+	@JoinColumn(name = "profile_image_id")
+	private Image profileImage;
+
 	@Builder
 	private Member(Long memberId, String email, String name, String nickname, Long studentNumber, Mbti mbti,
-		String phoneNumber, BirthDate birthDate, Boolean isActive, Gender gender, Role role, String refreshToken) {
+		String phoneNumber, BirthDate birthDate, Boolean isActive, Gender gender, Role role,
+		String refreshToken, Image profileImage) {
 		this.memberId = memberId;
 		this.email = email;
 		this.name = name;
@@ -77,6 +86,7 @@ public class Member extends BaseTimeEntity {
 		this.gender = gender;
 		this.role = role;
 		this.refreshToken = refreshToken;
+		this.profileImage = profileImage; // 추가된 필드
 	}
 
 	private static Member create(String email, String nickname, Mbti mbti, String phoneNumber, int year, int month,
@@ -107,8 +117,8 @@ public class Member extends BaseTimeEntity {
 			.build();
 	}
 
-	public void updateMemberDetails(String nickname, String phoneNumber, Long studentNumber, Gender
-		gender, BirthDate birthDate, Mbti mbti) {
+	public void updateMemberDetails(String nickname, String phoneNumber, Long studentNumber, Gender gender,
+		BirthDate birthDate, Mbti mbti, Image profileImage) {
 		this.nickname = nickname;
 		this.phoneNumber = phoneNumber;
 		this.studentNumber = studentNumber;
@@ -117,6 +127,7 @@ public class Member extends BaseTimeEntity {
 		this.birthDate = birthDate;
 		this.isActive = true;
 		this.mbti = mbti;
+		this.profileImage = profileImage;
 	}
 
 	public void updateRefreshToken(String updateRefreshToken) {
@@ -129,6 +140,10 @@ public class Member extends BaseTimeEntity {
 
 	public void updateMbti(Mbti mbti) {
 		this.mbti = mbti;
+	}
+
+	public void updateProfileImage(Image profileImage) {
+		this.profileImage = profileImage;
 	}
 
 	//

--- a/src/main/java/com/example/eatmate/app/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/domain/repository/MemberRepository.java
@@ -1,15 +1,25 @@
 package com.example.eatmate.app.domain.member.domain.repository;
 
-import com.example.eatmate.app.domain.member.domain.Member;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.example.eatmate.app.domain.member.domain.Member;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmail(String email);
-    Optional<Member> findByRefreshToken(String refreshToken);
-    boolean existsByNickname(String nickname);
-    boolean existsByPhoneNumber(String phoneNumber);
-    boolean existsByStudentNumber(Long studentNumber);
+	Optional<Member> findByEmail(String email);
+
+	Optional<Member> findByRefreshToken(String refreshToken);
+
+	boolean existsByNickname(String nickname);
+
+	boolean existsByPhoneNumber(String phoneNumber);
+
+	boolean existsByStudentNumber(Long studentNumber);
+
+	@Query("SELECT m FROM Member m LEFT JOIN FETCH m.profileImage WHERE m.email = :email")
+	Optional<Member> findByEmailWithProfileImage(@Param("email") String email);
 }
 

--- a/src/main/java/com/example/eatmate/app/domain/member/dto/MemberSignUpRequestDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/dto/MemberSignUpRequestDto.java
@@ -1,41 +1,46 @@
 package com.example.eatmate.app.domain.member.dto;
 
-
 import com.example.eatmate.app.domain.member.domain.Gender;
 import com.example.eatmate.app.domain.member.domain.Mbti;
-import jakarta.validation.constraints.*;
+
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 
 @NoArgsConstructor
 @Getter
 public class MemberSignUpRequestDto {
-    //프로필 사진  추후 추가 예정
-    @Min(1900) @Max(2100)
-    private int year;
+	//프로필 사진  추후 추가 예정
+	@Min(1900)
+	@Max(2100)
+	private int year;
 
-    @Min(1) @Max(12)
-    private int month;
+	@Min(1)
+	@Max(12)
+	private int month;
 
-    @Min(1) @Max(31)
-    private int day;
+	@Min(1)
+	@Max(31)
+	private int day;
 
-    @NotNull(message = "성별 선택은 필수 항목입니다.")
-    private Gender gender;
+	@NotNull(message = "성별 선택은 필수 항목입니다.")
+	private Gender gender;
 
-    @NotNull(message = "전화번호 입력은 필수입니다.")
-    @Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하며 11자리 숫자여야 합니다.")
-    private String phoneNumber;
+	@NotNull(message = "전화번호 입력은 필수입니다.")
+	@Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하며 11자리 숫자여야 합니다.")
+	private String phoneNumber;
 
-    private Mbti mbti;
+	private Mbti mbti;
 
-    @NotNull(message = "학번 입력은 필수입니다.")
-    @Digits(integer = 9, fraction = 0, message = "9자리의 학번을 입력해주세요. 예 )202512345")
-    private Long studentNumber;
+	@NotNull(message = "학번 입력은 필수입니다.")
+	@Digits(integer = 9, fraction = 0, message = "9자리의 학번을 입력해주세요. 예 )202512345")
+	private Long studentNumber;
 
-    @Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,12}$", message = "닉네임은 한글, 영문, 숫자로 이루어진 2~12자여야 하며 공백이 없어야 합니다.")
-    private String nickname;
-
+	@Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,12}$", message = "닉네임은 한글, 영문, 숫자로 이루어진 2~12자여야 하며 공백이 없어야 합니다.")
+	private String nickname;
 
 }

--- a/src/main/java/com/example/eatmate/app/domain/member/dto/MyInfoResponseDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/dto/MyInfoResponseDto.java
@@ -17,16 +17,18 @@ public class MyInfoResponseDto {
 	private Mbti mbti;
 	private String phoneNumber;
 	private BirthDate birthDate;
+	private String profileImageUrl;
 
 	@Builder
 	private MyInfoResponseDto(String email, String nickname, Long studentNumber, Mbti mbti, String phoneNumber,
-		BirthDate birthDate) {
+		BirthDate birthDate, String profileImageUrl) {
 		this.email = email;
 		this.nickname = nickname;
 		this.studentNumber = studentNumber;
 		this.mbti = mbti;
 		this.phoneNumber = phoneNumber;
 		this.birthDate = birthDate;
+		this.profileImageUrl = profileImageUrl;
 	}
 
 	public static MyInfoResponseDto from(Member member) {
@@ -37,6 +39,7 @@ public class MyInfoResponseDto {
 			.mbti(member.getMbti())
 			.birthDate(member.getBirthDate())
 			.phoneNumber(member.getPhoneNumber())
+			.profileImageUrl(member.getProfileImage().getImageUrl())
 			.build();
 	}
 }

--- a/src/main/java/com/example/eatmate/app/domain/member/dto/MyInfoResponseDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/dto/MyInfoResponseDto.java
@@ -39,7 +39,7 @@ public class MyInfoResponseDto {
 			.mbti(member.getMbti())
 			.birthDate(member.getBirthDate())
 			.phoneNumber(member.getPhoneNumber())
-			.profileImageUrl(member.getProfileImage().getImageUrl())
+			.profileImageUrl(member.getProfileImage() != null ? member.getProfileImage().getImageUrl() : null)
 			.build();
 	}
 }

--- a/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
@@ -96,7 +96,8 @@ public class MemberService {
 	}
 
 	//프로필 수정 메서드
-	public MyInfoResponseDto updateMyInfo(UserDetails userDetails, MyInfoUpdateRequestDto myInfoUpdateRequestDto) {
+	public MyInfoResponseDto updateMyInfo(UserDetails userDetails, MyInfoUpdateRequestDto myInfoUpdateRequestDto,
+		MultipartFile profileImage) {
 		// 로그인한 사용자의 이메일로 Member 조회
 		String email = userDetails.getUsername();
 		Member member = memberRepository.findByEmail(email)
@@ -117,6 +118,9 @@ public class MemberService {
 		if (myInfoUpdateRequestDto.getMbti() != null) {
 			member.updateMbti(myInfoUpdateRequestDto.getMbti());
 		}
+
+		Image profileImageEntity = imageSaveService.uploadImage(profileImage, ImageType.PROFILE);
+		member.updateProfileImage(profileImageEntity);
 
 		// 업데이트된 Member 정보 반환
 		return MyInfoResponseDto.from(member);

--- a/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
@@ -81,7 +81,7 @@ public class MemberService {
 
 		String email = userDetails.getUsername();
 
-		Member member = memberRepository.findByEmail(email)
+		Member member = memberRepository.findByEmailWithProfileImage(email)
 			.orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
 		return MyInfoResponseDto.from(member);
@@ -92,7 +92,7 @@ public class MemberService {
 		MultipartFile profileImage) {
 		// 로그인한 사용자의 이메일로 Member 조회
 		String email = userDetails.getUsername();
-		Member member = memberRepository.findByEmail(email)
+		Member member = memberRepository.findByEmailWithProfileImage(email)
 			.orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
 		// 닉네임 중복 확인

--- a/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
@@ -1,7 +1,5 @@
 package com.example.eatmate.app.domain.member.service;
 
-import java.util.List;
-
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +35,7 @@ public class MemberService {
 		UserDetails userDetails) {
 
 		// 프로필 이미지 업로드 처리
-		Image profileImageEntity = imageSaveService.uploadImage(profileImage, ImageType.PROFILE);
+		Image profileImageEntity = uploadProfileImage(profileImage);
 
 		// 기존 회원가입 로직
 		String email = userDetails.getUsername();
@@ -74,12 +72,6 @@ public class MemberService {
 		// 닉네임 중복 확인
 		if (memberRepository.existsByNickname(signUpRequestDto.getNickname())) {
 			throw new CommonException(ErrorCode.DUPLICATE_NICKNAME);
-		}
-
-		// 파일 확장자 검증
-		String fileExtension = getFileExtension(profileImage.getOriginalFilename());
-		if (!isSupportedFileExtension(fileExtension)) {
-			throw new CommonException(ErrorCode.WRONG_IMAGE_FORMAT);
 		}
 
 	}
@@ -119,7 +111,8 @@ public class MemberService {
 			member.updateMbti(myInfoUpdateRequestDto.getMbti());
 		}
 
-		Image profileImageEntity = imageSaveService.uploadImage(profileImage, ImageType.PROFILE);
+		// 프로필 이미지 업로드 처리
+		Image profileImageEntity = uploadProfileImage(profileImage);
 		member.updateProfileImage(profileImageEntity);
 
 		// 업데이트된 Member 정보 반환
@@ -145,15 +138,11 @@ public class MemberService {
 		return MemberLoginResponseDto.of(accessToken, refreshToken);
 	}
 
-	private boolean isSupportedFileExtension(String fileExtension) {
-		return List.of("jpg", "jpeg", "png").contains(fileExtension.toLowerCase());
-	}
-
-	private String getFileExtension(String fileName) {
-		if (fileName == null || !fileName.contains(".")) {
-			return "";
+	private Image uploadProfileImage(MultipartFile profileImage) {
+		if (profileImage != null && !profileImage.isEmpty()) {
+			return imageSaveService.uploadImage(profileImage, ImageType.PROFILE);
 		}
-		return fileName.substring(fileName.lastIndexOf(".") + 1);
+		return null; // 프로필 이미지가 없으면 null 반환
 	}
 
 }

--- a/src/main/java/com/example/eatmate/global/auth/login/controller/AuthController.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/controller/AuthController.java
@@ -38,7 +38,7 @@ public class AuthController {
 	@Operation(summary = "회원가입", description = "회원가입을 합니다.")
 	public ResponseEntity<GlobalResponseDto<Void>> register(
 		@RequestPart(value = "data") @Valid MemberSignUpRequestDto memberSignUpRequestDto,
-		@RequestPart(value = "profileImage") MultipartFile profileImage,
+		@RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
 		@AuthenticationPrincipal UserDetails userDetails) {
 
 		log.info("Received profileImage in controller: {}",

--- a/src/main/java/com/example/eatmate/global/auth/login/controller/AuthController.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/controller/AuthController.java
@@ -1,20 +1,15 @@
 package com.example.eatmate.global.auth.login.controller;
 
-import com.example.eatmate.global.auth.jwt.JwtService;
-import com.example.eatmate.global.auth.login.dto.UserLoginResponseDto;
-import com.example.eatmate.global.auth.login.service.LoginService;
-import com.example.eatmate.global.config.error.exception.CommonException;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.eatmate.app.domain.member.dto.MemberSignUpRequestDto;
 import com.example.eatmate.app.domain.member.service.MemberService;
@@ -27,7 +22,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -37,15 +34,19 @@ public class AuthController {
 	private final JwtService jwtService;
 	private final LoginService loginService;
 
-	//회원가입
-	@PostMapping("/signup") //매핑 경로 수정
+	@PostMapping("/signup")
 	@Operation(summary = "회원가입", description = "회원가입을 합니다.")
 	public ResponseEntity<GlobalResponseDto<Void>> register(
-		@RequestBody @Valid MemberSignUpRequestDto memberSignUpRequestDto,
+		@RequestPart(value = "data") @Valid MemberSignUpRequestDto memberSignUpRequestDto,
+		@RequestPart(value = "profileImage") MultipartFile profileImage,
 		@AuthenticationPrincipal UserDetails userDetails) {
 
+		log.info("Received profileImage in controller: {}",
+			profileImage != null ? profileImage.getOriginalFilename() : "null");
+
 		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(GlobalResponseDto.success(memberService.completeRegistration(memberSignUpRequestDto, userDetails),
+			.body(GlobalResponseDto.success(
+				memberService.completeRegistration(memberSignUpRequestDto, profileImage, userDetails),
 				HttpStatus.CREATED.value()));
 	}
 


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #이슈
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<구현기능>
S3 구현에 맞추어 기존의 회원가입 방식 + 프로필 사진 설정 추가
본인 프로필 조회 -> 프로필 사진 조회 추가
본인 프로필 수정 -> 프로필 사진 수정 추가  하였습니다.

상대방 프로필 조회같은 경우에는 필드가 , 프로필사진, 메이트점수, 차단여부로 구성되어 있고, 메이트점수 & 차단여부 위 2개의 필드는 아직 세부사항이 나오지않아 나오면 추후 구현하겠습니다.

@OneToOne 어노테이션을 사용해 Member와 Image를 1:1 관계로 매핑했습니다.

orphanRemoval = true를 설정해, 기존 이미지를 다른 이미지로 변경할 때 이전 이미지를 자동으로 삭제하도록 구현했습니다.

이미지같은 경우 null은 불가능하게 설계하였으며, 프론트 분과의 이야기에 따라 프로필사진 설정 or 기본이미지 설정으로 하기로 하여서 이 부분은 변동사항 발생 시, 말씀드리겠습니다.

Dto에 이미지필드를 넣어서 처리하는 방식은 컨트롤러로 넘어가지 못하는 오류가 있어, 
요청 Dto에서는 이미지 필드를 넣지 않고, 
<img width="697" alt="스크린샷 2025-01-18 오전 12 46 58" src="https://github.com/user-attachments/assets/2cbae33a-de89-43fa-908d-f04bcf4ff5a8" />
요청할 때에 나머지 정보들은 key : data, value : Json 형식으로 입력, 사진은 profileImage (file형태) value에서 원하는 사진 넣어서 (지원하는 확장자만) 요청 보내었습니다.


반환Dto에는 이미지url이 반환되게끔 하였고, 수정 Dto또한 요청dto에는 이미지필드가 없습니다.

null 처리는 컨트롤러에 @RequestPart(value = "profileImage") MultipartFile profileImage 위부분에 
require=false라는 조건을 넣지 않을 시, spring이 자동으로 require=true로 인식하여 null 검증을 해줍니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
S3과 연동하여서 api를 설계하는 것이 처음이라 더 좋은 설계가 있다면 피드백 부탁드립니다!