### PR TITLE
[Feat] 상대방 프로필 조회 구현

### DIFF
--- a/src/main/java/com/example/eatmate/app/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +17,7 @@ import com.example.eatmate.app.domain.member.dto.MemberLoginRequestDto;
 import com.example.eatmate.app.domain.member.dto.MemberLoginResponseDto;
 import com.example.eatmate.app.domain.member.dto.MyInfoResponseDto;
 import com.example.eatmate.app.domain.member.dto.MyInfoUpdateRequestDto;
+import com.example.eatmate.app.domain.member.dto.UserInfoResponseDto;
 import com.example.eatmate.app.domain.member.service.MemberService;
 import com.example.eatmate.global.response.GlobalResponseDto;
 
@@ -46,6 +48,15 @@ public class MemberController {
 		// 서비스 호출 및 응답 반환
 		return ResponseEntity.ok(
 			GlobalResponseDto.success(memberService.getMyInfo(userDetails))
+		);
+	}
+
+	@GetMapping("/info/{memberId}")
+	@Operation(summary = "상대방 정보 조회", description = "상대방 프로필 정보를 조회합니다.")
+	public ResponseEntity<GlobalResponseDto<UserInfoResponseDto>> getProfileInfo(
+		@PathVariable Long memberId) {
+		return ResponseEntity.ok(
+			GlobalResponseDto.success(memberService.getProfileInfo(memberId))
 		);
 	}
 

--- a/src/main/java/com/example/eatmate/app/domain/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/domain/repository/MemberRepository.java
@@ -21,5 +21,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	@Query("SELECT m FROM Member m LEFT JOIN FETCH m.profileImage WHERE m.email = :email")
 	Optional<Member> findByEmailWithProfileImage(@Param("email") String email);
+
+	@Query("SELECT m FROM Member m LEFT JOIN FETCH m.profileImage WHERE m.memberId = :memberId")
+	Optional<Member> findByIdWithProfileImage(@Param("memberId") Long id);
 }
 

--- a/src/main/java/com/example/eatmate/app/domain/member/dto/UserInfoResponseDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/dto/UserInfoResponseDto.java
@@ -1,13 +1,35 @@
 package com.example.eatmate.app.domain.member.dto;
 
-import lombok.AllArgsConstructor;
+import com.example.eatmate.app.domain.member.domain.Mbti;
+import com.example.eatmate.app.domain.member.domain.Member;
+
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class UserInfoResponseDto {
-    private final String userNickname;
-    // 프로필 사진
-    // 차단 여부
-    // 레벨
+	private Long memberId;        // memberId 추가
+	private String profileImageUrl;
+	private String nickname;
+	private Mbti mbti;
+
+	@Builder
+	public UserInfoResponseDto(Long memberId, String profileImageUrl, String nickname, Mbti mbti) {
+		this.memberId = memberId;
+		this.profileImageUrl = profileImageUrl;
+		this.nickname = nickname;
+		this.mbti = mbti;
+	}
+
+	// 정적 팩토리 메서드
+	public static UserInfoResponseDto from(Member member) {
+		return UserInfoResponseDto.builder()
+			.memberId(member.getMemberId())
+			.profileImageUrl(
+				member.getProfileImage() != null ? member.getProfileImage().getImageUrl() : null
+			)
+			.nickname(member.getNickname())
+			.mbti(member.getMbti())
+			.build();
+	}
 }

--- a/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
@@ -16,6 +16,7 @@ import com.example.eatmate.app.domain.member.dto.MemberLoginResponseDto;
 import com.example.eatmate.app.domain.member.dto.MemberSignUpRequestDto;
 import com.example.eatmate.app.domain.member.dto.MyInfoResponseDto;
 import com.example.eatmate.app.domain.member.dto.MyInfoUpdateRequestDto;
+import com.example.eatmate.app.domain.member.dto.UserInfoResponseDto;
 import com.example.eatmate.global.auth.jwt.JwtService;
 import com.example.eatmate.global.config.error.ErrorCode;
 import com.example.eatmate.global.config.error.exception.CommonException;
@@ -85,6 +86,16 @@ public class MemberService {
 			.orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
 		return MyInfoResponseDto.from(member);
+	}
+
+	// 상대방 프로필 조회 메서드
+	public UserInfoResponseDto getProfileInfo(Long memberId) {
+		// 1. Member 엔티티 조회
+		Member member = memberRepository.findByIdWithProfileImage(memberId)
+			.orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+		// 2. DTO 변환 후 반환
+		return UserInfoResponseDto.from(member);
 	}
 
 	//프로필 수정 메서드


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #73 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
상대방 프로필을 클릭하였을 때 조회하는 로직을 구현하였습니다
<img width="719" alt="스크린샷 2025-01-21 오전 12 41 55" src="https://github.com/user-attachments/assets/55fd5b39-2865-4cdc-afdc-7ea5600472cc" />

메이트 점수 필드 요구사항이 빠짐에 따라,  닉네임, mbti, 프로필사진,memberId가 반환됩니다

<!---- Resolves: #73  -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
