### PR TITLE
[Refactor] 로그인 에러 페이지 반환

### DIFF
--- a/src/main/java/com/example/eatmate/app/domain/meeting/domain/DeliveryMeeting.java
+++ b/src/main/java/com/example/eatmate/app/domain/meeting/domain/DeliveryMeeting.java
@@ -38,6 +38,7 @@ public class DeliveryMeeting extends Meeting {
 	private String accountNumber;
 
 	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
 	private BankName bankName;
 
 	public void updateDeliveryMeeting(
@@ -47,13 +48,14 @@ public class DeliveryMeeting extends Meeting {
 		String storeName,
 		String pickupLocation,
 		String accountNumber,
+		BankName bankName,
 		Image backgroundImage
 	) {
 		super.updateMeeting(meetingName, description, backgroundImage);
-
 		this.foodCategory = foodCategory;
 		this.storeName = storeName;
 		this.pickupLocation = pickupLocation;
 		this.accountNumber = accountNumber;
+		this.bankName = bankName;
 	}
 }

--- a/src/main/java/com/example/eatmate/app/domain/meeting/domain/repository/MeetingCustomRepositoryImpl.java
+++ b/src/main/java/com/example/eatmate/app/domain/meeting/domain/repository/MeetingCustomRepositoryImpl.java
@@ -313,7 +313,8 @@ public class MeetingCustomRepositoryImpl implements MeetingCustomRepository {
 			meeting.participantLimit.maxParticipants,
 			deliveryMeeting.storeName.as("location"),
 			meeting.createdAt,
-			deliveryMeeting.orderDeadline.as("dueDateTime")
+			deliveryMeeting.orderDeadline.as("dueDateTime"),
+			meeting.chatRoom.lastChatAt
 		);
 	}
 
@@ -326,7 +327,8 @@ public class MeetingCustomRepositoryImpl implements MeetingCustomRepository {
 			meeting.participantLimit.maxParticipants,
 			offlineMeeting.meetingPlace.as("location"),
 			meeting.createdAt,
-			offlineMeeting.meetingDate.as("dueDateTime")
+			offlineMeeting.meetingDate.as("dueDateTime"),
+			meeting.chatRoom.lastChatAt
 		);
 	}
 

--- a/src/main/java/com/example/eatmate/app/domain/meeting/dto/MeetingDetailResponseDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/meeting/dto/MeetingDetailResponseDto.java
@@ -18,12 +18,13 @@ public class MeetingDetailResponseDto {
 	private LocalDateTime dueDateTime;
 	private String backgroundImage;
 	private Boolean isOwner;
+	private Boolean isCurrentUser;
 	private List<ParticipantDto> participants;
 
 	@Builder
 	private MeetingDetailResponseDto(String meetingType, String meetingName, String meetingDescription,
 		GenderRestriction genderRestriction, String location, LocalDateTime dueDateTime,
-		String backgroundImage, Boolean isOwner, List<ParticipantDto> participants) {
+		String backgroundImage, Boolean isOwner, Boolean isCurrentUser, List<ParticipantDto> participants) {
 		this.meetingType = meetingType;
 		this.meetingName = meetingName;
 		this.meetingDescription = meetingDescription;
@@ -32,6 +33,7 @@ public class MeetingDetailResponseDto {
 		this.dueDateTime = dueDateTime;
 		this.backgroundImage = backgroundImage;
 		this.isOwner = isOwner;
+		this.isCurrentUser = isCurrentUser;
 		this.participants = participants;
 	}
 
@@ -39,22 +41,27 @@ public class MeetingDetailResponseDto {
 	public static class ParticipantDto {
 		private Long userId;
 		private String name;
+		private String userProfileImage;
 		private Boolean isOwner;
 		private Boolean isCurrentUser;
 
 		@Builder
-		private ParticipantDto(Long userId, String name, Boolean isOwner, Boolean isCurrentUser) {
+		private ParticipantDto(Long userId, String name, Boolean isOwner, Boolean isCurrentUser,
+			String userProfileImage) {
 			this.userId = userId;
 			this.name = name;
+			this.userProfileImage = userProfileImage;
 			this.isOwner = isOwner;
 			this.isCurrentUser = isCurrentUser;
 		}
 
-		public static ParticipantDto createParticipantDto(Long userId, String name, Boolean isOwner,
+		public static ParticipantDto createParticipantDto(Long userId, String name, String userProfileImage,
+			Boolean isOwner,
 			Boolean isCurrentUser) {
 			return ParticipantDto.builder()
 				.userId(userId)
 				.name(name)
+				.userProfileImage(userProfileImage)
 				.isOwner(isOwner)
 				.isCurrentUser(isCurrentUser)
 				.build();

--- a/src/main/java/com/example/eatmate/app/domain/meeting/dto/MeetingListResponseDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/meeting/dto/MeetingListResponseDto.java
@@ -14,10 +14,11 @@ public class MeetingListResponseDto {
 	private String location;
 	private LocalDateTime createdAt;
 	private LocalDateTime dueDateTime;
+	private LocalDateTime lastChatAt;
 
 	public MeetingListResponseDto(Long meetingId, String meetingName, String meetingDescription,
 		Long currentParticipantCount, Long maxParticipants, String location, LocalDateTime createdAt,
-		LocalDateTime dueDateTime) {
+		LocalDateTime dueDateTime, LocalDateTime lastChatAt) {
 		this.meetingId = meetingId;
 		this.meetingName = meetingName;
 		this.meetingDescription = meetingDescription;
@@ -26,6 +27,7 @@ public class MeetingListResponseDto {
 		this.location = location;
 		this.createdAt = createdAt;
 		this.dueDateTime = dueDateTime;
+		this.lastChatAt = lastChatAt;
 	}
 }
 

--- a/src/main/java/com/example/eatmate/app/domain/meeting/dto/UpdateDeliveryMeetingRequestDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/meeting/dto/UpdateDeliveryMeetingRequestDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import com.example.eatmate.app.domain.meeting.domain.BankName;
 import com.example.eatmate.app.domain.meeting.domain.FoodCategory;
 
 import jakarta.validation.constraints.Future;
@@ -33,6 +34,8 @@ public class UpdateDeliveryMeetingRequestDto {
 
 	@Pattern(regexp = "^[0-9-]*$", message = "올바른 계좌번호 형식이 아닙니다")
 	private String accountNumber;
+
+	private BankName bankName;
 
 	private MultipartFile backgroundImage;
 }

--- a/src/main/java/com/example/eatmate/app/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/controller/MemberController.java
@@ -63,7 +63,7 @@ public class MemberController {
 	@PatchMapping("/myinfo")
 	@Operation(summary = "프로필 수정", description = "사용자의 닉네임, 전화번호, MBTI, 생년월일을 일부 수정합니다.")
 	public ResponseEntity<GlobalResponseDto<MyInfoResponseDto>> updateMyProfile(
-		@RequestPart(value = "data") @Valid MyInfoUpdateRequestDto updateRequestDto,
+		@RequestPart(value = "data", required = false) @Valid MyInfoUpdateRequestDto updateRequestDto,
 		@RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
 		@AuthenticationPrincipal UserDetails userDetails
 	) {

--- a/src/main/java/com/example/eatmate/app/domain/member/dto/MemberSignUpRequestDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/dto/MemberSignUpRequestDto.java
@@ -43,4 +43,8 @@ public class MemberSignUpRequestDto {
 	@Pattern(regexp = "^[가-힣a-zA-Z0-9]{2,12}$", message = "닉네임은 한글, 영문, 숫자로 이루어진 2~12자여야 하며 공백이 없어야 합니다.")
 	private String nickname;
 
+	public void setMbti(String mbti) {
+		this.mbti = mbti != null ? Mbti.valueOf(mbti.toUpperCase()) : null;
+	}
+
 }

--- a/src/main/java/com/example/eatmate/app/domain/member/dto/MyInfoUpdateRequestDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/dto/MyInfoUpdateRequestDto.java
@@ -13,4 +13,8 @@ public class MyInfoUpdateRequestDto {
 
 	private Mbti mbti;
 
+	public void setMbti(String mbti) {
+		this.mbti = mbti != null ? Mbti.valueOf(mbti.toUpperCase()) : null;
+	}
+
 }

--- a/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
@@ -107,20 +107,22 @@ public class MemberService {
 		Member member = memberRepository.findByEmailWithProfileImage(email)
 			.orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
 
-		// 닉네임 중복 확인
-		if (myInfoUpdateRequestDto.getNickname() != null &&
-			memberRepository.existsByNickname(myInfoUpdateRequestDto.getNickname())) {
-			throw new CommonException(ErrorCode.DUPLICATE_NICKNAME);
-		}
+		if (myInfoUpdateRequestDto != null) {
+			// 닉네임 중복 확인
+			if (myInfoUpdateRequestDto.getNickname() != null &&
+				memberRepository.existsByNickname(myInfoUpdateRequestDto.getNickname())) {
+				throw new CommonException(ErrorCode.DUPLICATE_NICKNAME);
+			}
 
-		// 닉네임 업데이트
-		if (myInfoUpdateRequestDto.getNickname() != null) {
-			member.updateNickname(myInfoUpdateRequestDto.getNickname());
-		}
+			// 닉네임 업데이트
+			if (myInfoUpdateRequestDto.getNickname() != null) {
+				member.updateNickname(myInfoUpdateRequestDto.getNickname());
+			}
 
-		// MBTI 업데이트
-		if (myInfoUpdateRequestDto.getMbti() != null) {
-			member.updateMbti(myInfoUpdateRequestDto.getMbti());
+			// MBTI 업데이트
+			if (myInfoUpdateRequestDto.getMbti() != null) {
+				member.updateMbti(myInfoUpdateRequestDto.getMbti());
+			}
 		}
 
 		// 프로필 이미지 업로드 처리

--- a/src/main/java/com/example/eatmate/global/auth/login/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/oauth/CustomOAuth2UserService.java
@@ -8,19 +8,19 @@ import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServ
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-
 
 import com.example.eatmate.app.domain.member.domain.Gender;
 import com.example.eatmate.app.domain.member.domain.Member;
 import com.example.eatmate.app.domain.member.domain.Role;
 import com.example.eatmate.app.domain.member.domain.repository.MemberRepository;
+import com.example.eatmate.global.config.error.ErrorCode;
+import com.example.eatmate.global.config.error.exception.CommonException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-//Spring Security가 OAuth 인증 후 사용자 정보를 가져와 처리하는 커스텀 서비스.
 
 @Slf4j
 @Service
@@ -33,45 +33,50 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 		log.info("CustomOAuth2UserService.loadUser() 실행 - OAuth2 로그인 요청 진입");
 
-		// 사용자 정보 로드
-		OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
-		OAuth2User oAuth2User = delegate.loadUser(userRequest);
+		try {
+			// 사용자 정보 로드
+			OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+			OAuth2User oAuth2User = delegate.loadUser(userRequest);
 
-		// 사용자 정보 추출
-		String userNameAttributeName = userRequest.getClientRegistration()
-			.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
-		Map<String, Object> attributes = oAuth2User.getAttributes();
+			// 사용자 정보 추출
+			String userNameAttributeName = userRequest.getClientRegistration()
+				.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+			Map<String, Object> attributes = oAuth2User.getAttributes();
 
-		// 사용자 정보를 매핑하여 추출
-		OAuthAttributes extractAttributes = OAuthAttributes.of(userNameAttributeName, attributes);
+			// 사용자 정보를 매핑하여 추출
+			OAuthAttributes extractAttributes = OAuthAttributes.of(userNameAttributeName, attributes);
 
-		// 이메일 도메인 필터링
-		validateEmailDomain(extractAttributes.getEmail());
+			// 이메일 도메인 필터링
+			validateEmailDomain(extractAttributes.getEmail());
 
-		// 사용자 정보 조회 또는 저장
-		Member member = getMember(extractAttributes);
+			// 사용자 정보 조회 또는 저장
+			Member member = getMember(extractAttributes);
 
+			Gender gender = member.getGender();
 
-		Gender gender = member.getGender();
+			// 사용자 정보를 CustomOAuth2User로 반환
+			return new CustomOAuth2User(
+				Collections.singleton(new SimpleGrantedAuthority(member.getRole() != null
+					? member.getRole().getRoleType() : Role.GUEST.getRoleType())),
+				attributes,
+				extractAttributes.getNameAttributeKey(),
+				member.getRole() != null ? member.getRole() : Role.GUEST,
+				gender
+			);
 
-
-		// 사용자 정보를 CustomOAuth2User로 반환
-		return new CustomOAuth2User(
-			Collections.singleton(new SimpleGrantedAuthority(member.getRole() != null
-				? member.getRole().getRoleType() : Role.GUEST.getRoleType())), // 권한 설정
-			attributes, // 사용자 속성
-			extractAttributes.getNameAttributeKey(), // 기본 식별자 키
-
-			member.getRole() != null ? member.getRole() : Role.GUEST, // Role 전달
-			gender
-		);
-
+		} catch (CommonException ex) {
+			throw new OAuth2AuthenticationException(
+				new OAuth2Error(ex.getErrorCode().getCode()),
+				ex.getErrorCode().getMessage(),
+				ex
+			);
+		}
 	}
 
 	// 가천 도메인 필터링
 	private void validateEmailDomain(String email) {
-		if (!email.endsWith("@gachon.ac.kr")) {
-			throw new IllegalArgumentException("가천대학교 학생만 이용가능합니다.");
+		if (email == null || !email.endsWith("@gachon.ac.kr")) {
+			throw new CommonException(ErrorCode.INVALID_EMAIL_DOMAIN);
 		}
 	}
 

--- a/src/main/java/com/example/eatmate/global/auth/login/oauth/OAuthLoginFailureHandler.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/oauth/OAuthLoginFailureHandler.java
@@ -30,7 +30,7 @@ public class OAuthLoginFailureHandler implements AuthenticationFailureHandler {
 			CommonException commonException = (CommonException)cause;
 			if (commonException.getErrorCode() == ErrorCode.INVALID_EMAIL_DOMAIN) {
 				log.error("가천대 이메일이 아님: {}", exception.getMessage());
-				response.sendRedirect("/invalid-email.html");
+				response.sendRedirect("https://develop.d4u0qurydeei4.amplifyapp.com/intro/oauth2/invalid-account");
 				return;
 			}
 		}

--- a/src/main/java/com/example/eatmate/global/auth/login/oauth/OAuthLoginFailureHandler.java
+++ b/src/main/java/com/example/eatmate/global/auth/login/oauth/OAuthLoginFailureHandler.java
@@ -6,6 +6,9 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
+import com.example.eatmate.global.config.error.ErrorCode;
+import com.example.eatmate.global.config.error.exception.CommonException;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -16,13 +19,27 @@ public class OAuthLoginFailureHandler implements AuthenticationFailureHandler {
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
 		AuthenticationException exception) throws IOException {
-		// 상태 코드 설정
-		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		// 원인 예외 찾기
+		Throwable cause = exception.getCause();
+		while (cause != null && !(cause instanceof CommonException)) {
+			cause = cause.getCause();
+		}
 
-		// 에러 메시지를 헤더에 추가
+		// CommonException이고 이메일 도메인 에러인 경우
+		if (cause instanceof CommonException) {
+			CommonException commonException = (CommonException)cause;
+			if (commonException.getErrorCode() == ErrorCode.INVALID_EMAIL_DOMAIN) {
+				log.error("가천대 이메일이 아님: {}", exception.getMessage());
+				response.sendRedirect("/invalid-email.html");
+				return;
+			}
+		}
+
+		// 그 외의 소셜 로그인 실패
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.setHeader("Error-Message", "소셜 로그인 실패");
 		response.setHeader("Error-Detail", exception.getMessage());
-
 		log.error("소셜 로그인 실패: {}", exception.getMessage());
 	}
 }
+

--- a/src/main/java/com/example/eatmate/global/config/error/ErrorCode.java
+++ b/src/main/java/com/example/eatmate/global/config/error/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
 	VALIDATION_FAILED(400, "VALIDATION_FAILED", "요청 값이 올바르지 않습니다."),
 	JSON_PARSING_ERROR(400, "JSON_PARSING_ERROR", "JSON 데이터 처리 중 오류가 발생했습니다"),
 	NO_RESOURCE_FOUND(404, "NO_RESOURCE_FOUND", "해당 리소스를 찾을 수 없습니다."),
+	INVALID_EMAIL_DOMAIN(400, "INVALID_EMAIL_DOMAIN", "가천대학교 이메일이 아닙니다."),
 
 	//회원
 	USER_NOT_FOUND(404, "USER_NOT_FOUND", "유저를 찾을 수 없습니다."),

--- a/src/main/java/com/example/eatmate/global/config/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/eatmate/global/config/error/exception/GlobalExceptionHandler.java
@@ -12,11 +12,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.servlet.View;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
-
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.example.eatmate.global.config.error.ErrorCode;
@@ -60,7 +57,7 @@ public class GlobalExceptionHandler {
 		// 이메일 도메인 에러일 경우 리다이렉트
 		if (errorCode == ErrorCode.INVALID_EMAIL_DOMAIN) {
 			redirectAttributes.addFlashAttribute("errorMessage", errorCode.getMessage());
-			return "redirect:/error/invalid-email";
+			return "redirect:https://develop.d4u0qurydeei4.amplifyapp.com/intro/oauth2/invalid-account";
 		}
 
 		// 그 외의 경우 API 응답

--- a/src/main/java/com/example/eatmate/global/config/error/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/eatmate/global/config/error/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import com.example.eatmate.global.config.error.ErrorCode;
@@ -48,13 +49,19 @@ public class GlobalExceptionHandler {
 			.body(GlobalResponseDto.fail(errorCode, errorResponse.getMessage()));
 	}
 
-	@ExceptionHandler(CommonException.class) // Custom Exception을 포괄적으로 처리
-	public ResponseEntity<GlobalResponseDto<String>> handleCommonException(CommonException ex) {
-		ErrorCode errorCode = ex.getErrorCode(); // 전달된 예외에서 에러 코드 가져오기
-		ErrorResponse errorResponse = new ErrorResponse(errorCode);
-		showErrorLog(errorCode);
+	@ExceptionHandler(CommonException.class)
+	public Object handleCommonException(CommonException ex, RedirectAttributes redirectAttributes) {
+		ErrorCode errorCode = ex.getErrorCode();
+
+		// 이메일 도메인 에러일 경우 리다이렉트
+		if (errorCode == ErrorCode.INVALID_EMAIL_DOMAIN) {
+			redirectAttributes.addFlashAttribute("errorMessage", errorCode.getMessage());
+			return "redirect:/error/invalid-email";
+		}
+
+		// 그 외의 경우 API 응답
 		return ResponseEntity.status(HttpStatus.valueOf(errorCode.getStatus()))
-			.body(GlobalResponseDto.fail(errorCode, errorResponse.getMessage()));
+			.body(GlobalResponseDto.fail(errorCode, new ErrorResponse(errorCode).getMessage()));
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class) // Valid 검증 실패시 예외처리


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #115 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
가천대 계정으로 로그인 한 것이 아닐 경우 나타나는 뷰 로직을 추가하였습니다.
추가로, 프로필 정보 수정 시, 원하는 필드만 수정가능하게끔 코드 수정 하였습니다.
![image](https://github.com/user-attachments/assets/1c3c7b2d-efc5-4cc0-9d6b-642c0947dcdb)
<img width="718" alt="스크린샷 2025-02-01 오전 2 09 54" src="https://github.com/user-attachments/assets/e5e45a52-cd76-4904-b27a-b2d4cec90efb" />

data 필드 중 ,닉네임 mbti중 바꾸고 싶은 필드의 값만 넣어주면 됩니다.
프로필을 바꾸고싶으면 data는 안넣어주시면 됩니다

<!---- Resolves: #115  -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
