### PR TITLE
[add] 모임 조회시 response 추가

### DIFF
--- a/src/main/java/com/example/eatmate/app/domain/meeting/domain/repository/MeetingCustomRepositoryImpl.java
+++ b/src/main/java/com/example/eatmate/app/domain/meeting/domain/repository/MeetingCustomRepositoryImpl.java
@@ -65,9 +65,22 @@ public class MeetingCustomRepositoryImpl implements MeetingCustomRepository {
 				meeting.id,
 				meeting.meetingName,
 				meeting.meetingStatus,
+				meeting.meetingDescription,
+				meeting.participantLimit.maxParticipants,
 				ExpressionUtils.as(
 					new CaseBuilder()
-						.when(meeting.type.eq("DELIVERY"))
+						.when(isDelivery)
+						.then(Expressions.nullExpression(OfflineMeetingCategory.class))
+						.otherwise(JPAExpressions
+							.select(offlineMeeting.offlineMeetingCategory)
+							.from(offlineMeeting)
+							.where(offlineMeeting.id.eq(meeting.id))),
+					"offlineMeetingCategory"
+				),
+				meeting.createdAt,
+				ExpressionUtils.as(
+					new CaseBuilder()
+						.when(isDelivery)
 						.then(JPAExpressions
 							.select(deliveryMeeting.storeName)
 							.from(deliveryMeeting)
@@ -79,7 +92,7 @@ public class MeetingCustomRepositoryImpl implements MeetingCustomRepository {
 					"location"),
 				ExpressionUtils.as(
 					new CaseBuilder()
-						.when(meeting.type.eq("DELIVERY"))
+						.when(isDelivery)
 						.then(JPAExpressions
 							.select(deliveryMeeting.orderDeadline)
 							.from(deliveryMeeting)

--- a/src/main/java/com/example/eatmate/app/domain/meeting/dto/MyMeetingListResponseDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/meeting/dto/MyMeetingListResponseDto.java
@@ -3,6 +3,7 @@ package com.example.eatmate.app.domain.meeting.dto;
 import java.time.LocalDateTime;
 
 import com.example.eatmate.app.domain.meeting.domain.MeetingStatus;
+import com.example.eatmate.app.domain.meeting.domain.OfflineMeetingCategory;
 
 import lombok.Getter;
 
@@ -12,27 +13,37 @@ public class MyMeetingListResponseDto {
 	private Long id;
 	private String meetingName;
 	private MeetingStatus meetingStatus;
-	private Long participantCount;
+	private String meetingDescription;
+	private Long maxParticipants;
+	private OfflineMeetingCategory offlineMeetingCategory;
+	private LocalDateTime createdAt;
 	private String location;
 	private LocalDateTime dueDateTime;
+	private Long participantCount;
 
 	public MyMeetingListResponseDto(
-		String type,
+		String meetingType,
 		Long id,
 		String meetingName,
 		MeetingStatus meetingStatus,
+		String meetingDescription,
+		Long maxParticipants,
+		OfflineMeetingCategory offlineMeetingCategory,
+		LocalDateTime createdAt,
 		String location,
 		LocalDateTime dueDateTime,
-		Long participantCount
-	) {
-		this.meetingType = type;
+		Long participantCount) {
+		
+		this.meetingType = meetingType;
 		this.id = id;
 		this.meetingName = meetingName;
 		this.meetingStatus = meetingStatus;
+		this.meetingDescription = meetingDescription;
+		this.maxParticipants = maxParticipants;
+		this.offlineMeetingCategory = offlineMeetingCategory;
+		this.createdAt = createdAt;
 		this.location = location;
 		this.dueDateTime = dueDateTime;
 		this.participantCount = participantCount;
 	}
-
 }
-


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #155
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

프론트엔드의 요청에 따라 내 모임 목록 조회시 반환 받는 필드값을 추가했습니다.

<img width="444" alt="스크린샷 2025-02-03 01 16 13" src="https://github.com/user-attachments/assets/87451c85-b752-4e8d-9b65-e6a9c2341b45" />

생성시간, 정원, 오프라인 모임의 경우 카테고리, 모임 설명을 추가했습니다

<!---- Resolves: #155 -->



## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
프론트에서 변경 요청사항이라 변경했습니다,,
빠르게 승인 부탁드립니다!!