### PR TITLE
[add] 채팅방 입장시 dto에 유저 정보 추가

### DIFF
--- a/src/main/java/com/example/eatmate/app/domain/chatRoom/dto/response/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/chatRoom/dto/response/ChatRoomResponseDto.java
@@ -5,8 +5,9 @@ import java.util.List;
 import org.springframework.data.domain.Slice;
 
 import com.example.eatmate.app.domain.chat.dto.response.ChatMessageResponseDto;
+import com.example.eatmate.app.domain.meeting.domain.MeetingParticipant;
+import com.example.eatmate.app.domain.meeting.domain.ParticipantRole;
 import com.example.eatmate.app.domain.member.domain.Mbti;
-import com.example.eatmate.app.domain.member.domain.Member;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -53,22 +54,28 @@ public class ChatRoomResponseDto {
 
 	@Getter
 	public static class ChatMemberResponseDto {
+		private Long memberId;
 		private String nickname;
 		private Mbti mbti;
 		private String profileImageUrl;
+		private ParticipantRole role;
 
 		@Builder
-		private ChatMemberResponseDto(String nickname, Mbti mbti, String profileImageUrl) {
+		private ChatMemberResponseDto(Long memberId, String nickname, Mbti mbti, String profileImageUrl, ParticipantRole role) {
+			this.memberId = memberId;
 			this.nickname = nickname;
 			this.mbti = mbti;
 			this.profileImageUrl = profileImageUrl;
+			this.role = role;
 		}
 
-		public static ChatMemberResponseDto from(Member member) {
+		public static ChatMemberResponseDto from(MeetingParticipant participant) {
 			return ChatMemberResponseDto.builder()
-				.nickname(member.getNickname())
-				.mbti(member.getMbti())
-				.profileImageUrl(member.getProfileImage().getImageUrl())
+				.memberId(participant.getMember().getMemberId())
+				.nickname(participant.getMember().getNickname())
+				.mbti(participant.getMember().getMbti())
+				.profileImageUrl(participant.getMember().getProfileImage().getImageUrl())
+				.role(participant.getRole())
 				.build();
 		}
 	}

--- a/src/main/java/com/example/eatmate/app/domain/chatRoom/dto/response/ChatRoomResponseDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/chatRoom/dto/response/ChatRoomResponseDto.java
@@ -59,23 +59,26 @@ public class ChatRoomResponseDto {
 		private Mbti mbti;
 		private String profileImageUrl;
 		private ParticipantRole role;
+		private Boolean isMine;
 
 		@Builder
-		private ChatMemberResponseDto(Long memberId, String nickname, Mbti mbti, String profileImageUrl, ParticipantRole role) {
+		private ChatMemberResponseDto(Long memberId, String nickname, Mbti mbti, String profileImageUrl, ParticipantRole role, Boolean isMine) {
 			this.memberId = memberId;
 			this.nickname = nickname;
 			this.mbti = mbti;
 			this.profileImageUrl = profileImageUrl;
 			this.role = role;
+			this.isMine = isMine;
 		}
 
-		public static ChatMemberResponseDto from(MeetingParticipant participant) {
+		public static ChatMemberResponseDto of(MeetingParticipant participant, Boolean isMine) {
 			return ChatMemberResponseDto.builder()
 				.memberId(participant.getMember().getMemberId())
 				.nickname(participant.getMember().getNickname())
 				.mbti(participant.getMember().getMbti())
 				.profileImageUrl(participant.getMember().getProfileImage().getImageUrl())
 				.role(participant.getRole())
+				.isMine(isMine)
 				.build();
 		}
 	}

--- a/src/main/java/com/example/eatmate/app/domain/meeting/dto/MeetingDetailResponseDto.java
+++ b/src/main/java/com/example/eatmate/app/domain/meeting/dto/MeetingDetailResponseDto.java
@@ -20,11 +20,12 @@ public class MeetingDetailResponseDto {
 	private Boolean isOwner;
 	private Boolean isCurrentUser;
 	private List<ParticipantDto> participants;
+	private Long chatRoomId;
 
 	@Builder
 	private MeetingDetailResponseDto(String meetingType, String meetingName, String meetingDescription,
 		GenderRestriction genderRestriction, String location, LocalDateTime dueDateTime,
-		String backgroundImage, Boolean isOwner, Boolean isCurrentUser, List<ParticipantDto> participants) {
+		String backgroundImage, Boolean isOwner, Boolean isCurrentUser, List<ParticipantDto> participants, Long chatRoomId) {
 		this.meetingType = meetingType;
 		this.meetingName = meetingName;
 		this.meetingDescription = meetingDescription;
@@ -35,6 +36,7 @@ public class MeetingDetailResponseDto {
 		this.isOwner = isOwner;
 		this.isCurrentUser = isCurrentUser;
 		this.participants = participants;
+		this.chatRoomId = chatRoomId;
 	}
 
 	@Getter

--- a/src/main/java/com/example/eatmate/app/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/example/eatmate/app/domain/meeting/service/MeetingService.java
@@ -287,6 +287,7 @@ public class MeetingService {
 			.isOwner(isOwner(meeting, member.getMemberId()))
 			.isCurrentUser(isCurrentUser(meeting, member))
 			.participants(participants)
+			.chatRoomId(meeting.getChatRoom().getId())
 			.build();
 	}
 


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #162
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. 모임 상세 조회시 채팅방 id도 조회되도록 수정(모임과 채팅방의 id가 차이나는 경우 발생)
2. 채팅방 입장 시 유저 id, 역할도 조회되록 수정
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
