### PR TITLE
 [mod] 프로필 수정 로직 일부 수정

### DIFF
--- a/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
@@ -126,9 +126,14 @@ public class MemberService {
 		}
 
 		// 프로필 이미지 업로드 처리
-		Image profileImageEntity = uploadProfileImage(profileImage);
-		member.updateProfileImage(profileImageEntity);
-
+		if (profileImage != null && !profileImage.isEmpty()) {
+			Image profileImageEntity = uploadProfileImage(profileImage);
+			member.updateProfileImage(profileImageEntity);
+		}
+		// 기존 이미지가 null이 아닐 경우 유지 (새로운 이미지가 업로드되지 않았을 때)
+		else if (member.getProfileImage() != null) {
+			member.updateProfileImage(member.getProfileImage()); // 기존 이미지 유지
+		}
 		// 업데이트된 Member 정보 반환
 		return MyInfoResponseDto.from(member);
 	}

--- a/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/eatmate/app/domain/member/service/MemberService.java
@@ -130,10 +130,7 @@ public class MemberService {
 			Image profileImageEntity = uploadProfileImage(profileImage);
 			member.updateProfileImage(profileImageEntity);
 		}
-		// 기존 이미지가 null이 아닐 경우 유지 (새로운 이미지가 업로드되지 않았을 때)
-		else if (member.getProfileImage() != null) {
-			member.updateProfileImage(member.getProfileImage()); // 기존 이미지 유지
-		}
+	
 		// 업데이트된 Member 정보 반환
 		return MyInfoResponseDto.from(member);
 	}


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #167 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
프로필 수정 시,  프로필 사진 제외하고 닉네임이나 MBTI를 변경하면 기존의 프로필 사진이 null 이 되어 , 기본 이미지로 변경되는 에러가 발생 하여서 프로필 이미지가 설정되 있는 상태에서 data 필드를 수정하면 기존 이미지를 유지하게끔 수정하였습니다.
<img width="721" alt="image" src="https://github.com/user-attachments/assets/f054afb9-9387-4a7c-957a-224330f8c99e" />

<!---- Resolves: #167 -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
간단한 사항이라,
큰 이상 없으시면 바로 승인해주시면 감사하겠습니다!