### PR TITLE
[feat] 서버 종료 후 재시작 시 채팅방 컨슈머 재생성

### DIFF
--- a/src/main/java/com/example/eatmate/app/domain/chat/service/QueueManager.java
+++ b/src/main/java/com/example/eatmate/app/domain/chat/service/QueueManager.java
@@ -128,7 +128,7 @@ public class QueueManager {
 			for (ChatRoom chatRoom : activeChatRoom) {
 				startChatRoomListener(chatRoom.getId());
 			}
-			log.info("✅ Restored {} chat room listeners from DB", activeChatRoom.size());
+			log.info("Restored {} chat room listeners from DB", activeChatRoom.size());
 		};
 	}
 

--- a/src/main/java/com/example/eatmate/app/domain/chatRoom/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/eatmate/app/domain/chatRoom/domain/repository/ChatRoomRepository.java
@@ -1,5 +1,6 @@
 package com.example.eatmate.app.domain.chatRoom.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 	@Query("SELECT c FROM ChatRoom c WHERE c.id = :id AND c.deletedStatus = :deletedStatus")
 	Optional<ChatRoom> findByIdAndDeletedStatus(@Param("id") Long id, @Param("deletedStatus") DeletedStatus deletedStatus);
+
+	@Query("SELECT c FROM ChatRoom c WHERE c.deletedStatus = :deletedStatus")
+	List<ChatRoom> findAllByDeletedStatus(@Param("deletedStatus") DeletedStatus deletedStatus);
+
 }


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #173
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 서버 재시작시 채팅방 컨슈머가 종료된 후 살아나지 않음. -> 재시작 시 자동으로 삭제되지 않은 채팅방의 컨슈머(리스너)를 재시작 하는 코드 추가
- 단, 테스트 채팅방이 많아 현재 재시작할 경우 많이 컨슈머가 살아날 것으로 예상 -> 필요에 따라 해당 pr을 머지해 사용하면 좋을 것 같습니다. (현재는 새로운 채팅방을 파야 살아납니다!)
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
